### PR TITLE
인터페이스를 활용한 oauth 설정 분리

### DIFF
--- a/src/main/java/com/cos/security1/config/oauth/PrincipalOauth2UserService.java
+++ b/src/main/java/com/cos/security1/config/oauth/PrincipalOauth2UserService.java
@@ -1,6 +1,9 @@
 package com.cos.security1.config.oauth;
 
 import com.cos.security1.auth.PrincipalDetails;
+import com.cos.security1.config.oauth.provider.FacebookUserInfo;
+import com.cos.security1.config.oauth.provider.GoogleUserInfo;
+import com.cos.security1.config.oauth.provider.OAuth2UserInfo;
 import com.cos.security1.model.User;
 import com.cos.security1.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,10 +37,24 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
 
         System.out.println("oAuth2User " + oAuth2User.getAttributes());
 
+        OAuth2UserInfo oAuth2UserInfo = null;
+
+        if (userRequest.getClientRegistration().getRegistrationId().equals("google")) {
+            System.out.println("구글 로그인 요청");
+            oAuth2UserInfo = new GoogleUserInfo(oAuth2User.getAttributes());
+        }
+        else if (userRequest.getClientRegistration().getRegistrationId().equals("facebook")) {
+            System.out.println("페이스북 로그인 요청");
+            oAuth2UserInfo = new FacebookUserInfo(oAuth2User.getAttributes());
+        }
+        else {
+            System.out.println("우리는 구글과 페이스북만 지원해요");
+        }
+
         // 강제 회원가입 진행
-        String provider = userRequest.getClientRegistration().getClientId(); // google
-        String providerId = oAuth2User.getAttribute("sub"); // google 의 id
-        String email = oAuth2User.getAttribute("email");
+        String provider = oAuth2UserInfo.getProvider(); // google
+        String providerId = oAuth2UserInfo.getProviderId(); // google 의 id
+        String email = oAuth2UserInfo.getEmail();
         String username = provider + "_" + providerId; // google_123123123, 충돌 방지를 위해
         String password = bCryptPasswordEncoder.encode("겟인데어");
         String role = "ROLE_USER";

--- a/src/main/java/com/cos/security1/config/oauth/provider/FacebookUserInfo.java
+++ b/src/main/java/com/cos/security1/config/oauth/provider/FacebookUserInfo.java
@@ -1,0 +1,32 @@
+package com.cos.security1.config.oauth.provider;
+
+import java.util.Map;
+
+public class FacebookUserInfo implements OAuth2UserInfo {
+
+    public Map<String, Object> attributes;
+
+    public FacebookUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getProvider() {
+        return "facebook";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String)attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String)attributes.get("name");
+    }
+}

--- a/src/main/java/com/cos/security1/config/oauth/provider/GoogleUserInfo.java
+++ b/src/main/java/com/cos/security1/config/oauth/provider/GoogleUserInfo.java
@@ -1,0 +1,32 @@
+package com.cos.security1.config.oauth.provider;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    public Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String)attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String)attributes.get("name");
+    }
+}

--- a/src/main/java/com/cos/security1/config/oauth/provider/OAuth2UserInfo.java
+++ b/src/main/java/com/cos/security1/config/oauth/provider/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package com.cos.security1.config.oauth.provider;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update #create update none
+      ddl-auto: create #create update none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true
@@ -34,8 +34,8 @@ spring:
               - profile
 
           facebook:
-            client-id: ???
-            client-secret: ???
+            client-id: ${FACEBOOK_CLIENT_ID}
+            client-secret: ${FACEBOOK_CLIENT_SECRET}
             scope:
               - email
               - public_profile

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -14,6 +14,8 @@
 </form>
 <a href="/oauth2/authorization/google">구글 로그인</a>
 <br/>
+<a href="/oauth2/authorization/facebook">페이스북 로그인</a>
+<br/>
 <a href="/joinForm">회원가입을 아직 하지 않으셨나요?</a>
 </body>
 </html>


### PR DESCRIPTION
인터페이스를 활용한 oauth 분리

덕분에 다른 oauth 로그인 기능을 추가하더라도 클래스 객체 하나만 생성해주면 된다.

This closes #13 